### PR TITLE
Add environment setup script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Example environment variables for the Agent project
+# Copy this file to `.env` and fill in your own values.
+OPENROUTER_API_KEY=
+FIRECRAWL_API_KEY=
+OLLAMA_MODEL=phi3
+OLLAMA_BASE_URL=http://localhost:11434

--- a/README.md
+++ b/README.md
@@ -6,18 +6,21 @@ This project features a DSPy-based agent that can run commands and interact with
 
 1.  **Ensure you are in the project root directory: `/home/tom/git/agent/`**
 
-2.  **Create and activate a Python virtual environment (if you haven't already for this project):**
+2.  **Run the setup script**
+    ```bash
+    ./setup_env.sh
+    ```
+    This creates a Python virtual environment in `.venv`, installs the requirements and
+    generates an `.env.example` file. Copy `.env.example` to `.env` and fill in your
+    API keys.
+
+3.  **(Manual setup)** If you prefer to do things manually, create and activate the virtual
+    environment and install dependencies yourself:
     ```bash
     python3.11 -m venv .venv
     source .venv/bin/activate
-    ```
-
-3.  **Install or update dependencies:**
-    If `requirements.txt` is new or you've just created it:
-    ```bash
     uv pip install -r requirements.txt
     ```
-    If you are adding to an existing `requirements.txt`, ensure the new packages are installed.
 
 4.  **Set up OpenRouter API key:**
     *   Create a free account at [OpenRouter](https://openrouter.ai/)

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Script to set up the Python environment for the Agent project
+set -euo pipefail
+
+PYTHON=${PYTHON:-python3.11}
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+    echo "$PYTHON not found, falling back to python3" >&2
+    PYTHON=python3
+fi
+
+if [ ! -d ".venv" ]; then
+    "$PYTHON" -m venv .venv
+fi
+
+source .venv/bin/activate
+
+# Install dependencies using uv if available, otherwise pip
+if command -v uv >/dev/null 2>&1; then
+    uv pip install -r requirements.txt
+else
+    pip install -r requirements.txt
+fi
+
+if [ ! -f .env ]; then
+    cat > .env.example <<'ENV'
+# Copy to .env and fill in your secrets
+OPENROUTER_API_KEY=
+FIRECRAWL_API_KEY=
+OLLAMA_MODEL=phi3
+OLLAMA_BASE_URL=http://localhost:11434
+ENV
+fi
+
+echo "Environment setup complete. Activate with 'source .venv/bin/activate'"


### PR DESCRIPTION
## Summary
- add `setup_env.sh` script to bootstrap a virtualenv and install dependencies
- provide `.env.example` template for required environment variables
- mention setup script in `README.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_684b3f743ba08322b63b43c66c4d4cff