### PR TITLE
Improve manual scoring interface

### DIFF
--- a/dspy_programs/active_learning.py
+++ b/dspy_programs/active_learning.py
@@ -33,19 +33,27 @@ def save_training_data(data):
 def manual_scoring_interface(data_point):
     print(f"\nData point: {data_point}")
     while True:
+        rating_str = input(
+            "Rate the quality of this data point (0-9 where 0=worst, 9=best, q to quit): "
+        ).strip().lower()
+
+        if rating_str == "q":
+            return None
+
+        if not rating_str:
+            print("Invalid input. Please enter a number between 0 and 9 or q to quit.")
+            continue
+
         try:
-            rating_str = input("Rate the quality of this data point (0-9 where 0=worst, 9=best): ").strip()
-            if not rating_str:
-                raise ValueError("Empty input")
-                
             rating = int(rating_str)
-            if rating < 0 or rating > 9:
-                print("Please enter a number between 0 and 9.")
-                continue
-                
-            return rating / 9.0
         except ValueError:
-            print("Invalid input. Please enter a number between 0 and 9.")
+            print("Invalid input. Please enter a number between 0 and 9 or q to quit.")
+            continue
+
+        if 0 <= rating <= 9:
+            return rating / 9.0
+
+        print("Please enter a number between 0 and 9 or q to quit.")
 
 def active_learning_loop():
     # Configure DSPy

--- a/tests/test_active_learning.py
+++ b/tests/test_active_learning.py
@@ -18,3 +18,17 @@ def test_save_and_load_training_data(training_path):
     assert len(loaded) == 1
     assert loaded[0].data_point == "x"
     assert loaded[0].score == 0.8
+
+
+def test_manual_scoring_interface_valid(monkeypatch):
+    inputs = iter(["-1", "foo", "5"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    score = active_learning.manual_scoring_interface("test")
+    assert score == pytest.approx(5 / 9.0)
+
+
+def test_manual_scoring_interface_quit(monkeypatch):
+    inputs = iter(["invalid", "q"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    score = active_learning.manual_scoring_interface("test")
+    assert score is None


### PR DESCRIPTION
## Summary
- expand manual scoring interface to accept `q` for quitting and loop until valid input
- add unit tests for manual scoring interface

## Testing
- `pytest -q tests/test_active_learning.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684b5f8606c88322b408b61dfe39f7f3